### PR TITLE
Samples update for April 2022

### DIFF
--- a/quickstarts/apps/directx/AoaSampleApp/AoaSampleApp.vcxproj
+++ b/quickstarts/apps/directx/AoaSampleApp/AoaSampleApp.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" />
+  <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <MinimalCoreWin>true</MinimalCoreWin>
@@ -413,15 +413,15 @@
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
-    <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.19.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.20.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>

--- a/quickstarts/apps/directx/AoaSampleApp/AoaSampleAppMain.cpp
+++ b/quickstarts/apps/directx/AoaSampleApp/AoaSampleAppMain.cpp
@@ -686,7 +686,7 @@ HolographicFrame AoaSampleAppMain::Update(HolographicFrame const& previousFrame)
             }
             else
             {
-                const SpatialPose modelPose = it->ComputeModelPoseForView({ viewLocation.Position(), viewLocation.Orientation() }, it->CoordinateSystemToPlacement);
+                const SpatialPose modelPose = it->ComputeOriginForView({ viewLocation.Position(), viewLocation.Orientation() }, it->CoordinateSystemToPlacement);
 
                 renderer.second.SetTransform(make_float4x4_from_quaternion(modelPose.Orientation) * make_float4x4_translation(modelPose.Position));
                 renderer.second.SetActive(true);

--- a/quickstarts/apps/directx/AoaSampleApp/Common/ObjectTracker.h
+++ b/quickstarts/apps/directx/AoaSampleApp/Common/ObjectTracker.h
@@ -7,6 +7,7 @@
 
 #include <winrt/Microsoft.Azure.ObjectAnchors.h>
 #include <winrt/Microsoft.Azure.ObjectAnchors.Diagnostics.h>
+#include <winrt/Microsoft.Azure.ObjectAnchors.SpatialGraph.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Perception.Spatial.h>
 
@@ -18,9 +19,9 @@
 
 namespace AoaSampleApp
 {
-    struct TrackedObject : winrt::Microsoft::Azure::ObjectAnchors::ObjectInstancePlacement
+    struct TrackedObject : winrt::Microsoft::Azure::ObjectAnchors::ObjectInstanceState, winrt::Microsoft::Azure::ObjectAnchors::SpatialGraph::SpatialGraphPlacement
     {
-        TrackedObject(ObjectInstancePlacement const& placement) : ObjectInstancePlacement(placement) {}
+        TrackedObject(ObjectInstanceState const& state, SpatialGraphPlacement const& placement) : ObjectInstanceState(state), SpatialGraphPlacement(placement) {}
 
         winrt::guid ModelId;
         winrt::Windows::Foundation::Numerics::float4x4 CoordinateSystemToPlacement;
@@ -74,7 +75,8 @@ namespace AoaSampleApp
         struct ObjectInstanceMetadata
         {
             winrt::Microsoft::Azure::ObjectAnchors::ObjectInstance::Changed_revoker ChangedSubscription;
-            winrt::Microsoft::Azure::ObjectAnchors::ObjectInstancePlacement Placement;
+            winrt::Microsoft::Azure::ObjectAnchors::ObjectInstanceState State;
+            winrt::Microsoft::Azure::ObjectAnchors::SpatialGraph::SpatialGraphPlacement Placement;
             winrt::Windows::Perception::Spatial::SpatialCoordinateSystem PlacementCoordinateSystem;
         };
 

--- a/quickstarts/apps/directx/AoaSampleApp/packages.config
+++ b/quickstarts/apps/directx/AoaSampleApp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.ObjectAnchors.Runtime.WinRT" version="0.19.0" targetFramework="native" />
+  <package id="Microsoft.Azure.ObjectAnchors.Runtime.WinRT" version="0.20.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210505.3" targetFramework="native" />
 </packages>

--- a/quickstarts/apps/unity/basic/Packages/manifest.json
+++ b/quickstarts/apps/unity/basic/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.arfoundation": "2.1.18",
-    "com.unity.xr.windowsmr": "2.9.0",
+    "com.unity.xr.windowsmr": "2.9.2",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/quickstarts/apps/unity/mrtk/Packages/manifest.json
+++ b/quickstarts/apps/unity/mrtk/Packages/manifest.json
@@ -28,7 +28,7 @@
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.arfoundation": "2.1.18",
-    "com.unity.xr.windowsmr": "2.9.0",
+    "com.unity.xr.windowsmr": "2.9.2",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/quickstarts/conversion/Conversion.sln
+++ b/quickstarts/conversion/Conversion.sln
@@ -1,7 +1,7 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConversionQuickstart", "ConversionQuickstart\ConversionQuickstart.csproj", "{FD2070B1-07DA-403A-9FF8-9E322361203F}"
 EndProject

--- a/quickstarts/conversion/ConversionQuickstart/ConversionQuickstart.csproj
+++ b/quickstarts/conversion/ConversionQuickstart/ConversionQuickstart.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>ConversionQuickstart</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.MixedReality.ObjectAnchors.Conversion" Version="0.3.0-beta.2" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.8" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
  - Updates to use AOA Runtime SDK 0.20.0 in detection samples.
  - Conversion Quickstart: Updated to .NET 6, which now requires Visual Studio 2022 if you're using Visual Studio.
  - DirectX Quickstart: Incorporated API changes from Azure Object Anchors 0.20.0.
  - Unity Basic and MRTK Quickstarts: Updated the `com.unity.xr.windowsmr` package to get related fixes.