### PR TITLE
Sample update for September 2022

### DIFF
--- a/quickstarts/apps/directx/AoaSampleApp/AoaSampleApp.vcxproj
+++ b/quickstarts/apps/directx/AoaSampleApp/AoaSampleApp.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" />
+  <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <MinimalCoreWin>true</MinimalCoreWin>
@@ -413,15 +413,15 @@
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
-    <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets" Condition="Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.24.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.0.25.0\build\native\Microsoft.Azure.ObjectAnchors.Runtime.WinRT.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>

--- a/quickstarts/apps/directx/AoaSampleApp/packages.config
+++ b/quickstarts/apps/directx/AoaSampleApp/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.ObjectAnchors.Runtime.WinRT" version="0.24.0" targetFramework="native" />
+  <package id="Microsoft.Azure.ObjectAnchors.Runtime.WinRT" version="0.25.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210505.3" targetFramework="native" />
 </packages>

--- a/quickstarts/conversion/ConversionQuickstart/ConversionQuickstart.csproj
+++ b/quickstarts/conversion/ConversionQuickstart/ConversionQuickstart.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.MixedReality.ObjectAnchors.Conversion" Version="0.3.0-beta.4" />
+    <PackageReference Include="Azure.MixedReality.ObjectAnchors.Conversion" Version="0.3.0-beta.5" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
  - Updated AOA Runtime SDK to 0.25.0.
  - Updated the conversion sample to use `Azure.MixedReality.ObjectAnchors.Conversion` 0.3.0-beta.5.